### PR TITLE
Closes JoshuaStorm/WebSynth/#1

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -10,8 +10,17 @@ var decaySlider, decay;
 var sustainSlider, sustain;
 var releaseSlider, release;
 
+var keyWidth, keyHeight;
+var xTranslate, yTranslate;
+
 function setup() {
   createCanvas(1440, 800);
+
+  //Initializing some GUI element properties
+  keyWidth = width / (4 * notes.length);
+  keyHeight = height / 4;
+  xTranslate = 800;
+  yTranslate = height / 2;
 
   setupSliders();
   
@@ -55,6 +64,8 @@ function setupSliders() {
 // A function to play a note
 function playNote(note) {
   
+  console.log("note played");
+  
   attack  = attackSlider.value();
   decay   = decaySlider.value();
   sustain = map(sustainSlider.value(), 0, 100, 0.0, 1.0);
@@ -75,20 +86,26 @@ function draw() {
   drawKeyboard();
 }
 
+//Determines if the mouse is over any key on the keyboard  
+function mouseOverKeys() {
+  if ( (mouseX > xTranslate) && (mouseX < (notes.length * keyWidth) + xTranslate) 
+    && (mouseY < keyHeight + yTranslate) && (mouseY > yTranslate) ) {
+  
+    return true;
+  } else {
+    return false;
+  }
+}
+
 
 function drawKeyboard() {
-  var keyWidth = width / (4 * notes.length);
-  var keyHeight = height / 4;
-  
-  var xTranslate = 800;
-  var yTranslate = height / 2;
   
   for (var i = 0; i < notes.length; i++) {
     var x = i * keyWidth;
     
     // If the mouse is over the key
     if ( (mouseX > x + xTranslate) && (mouseX < x + keyWidth + xTranslate) 
-    && (mouseY < keyHeight + yTranslate) && (mouseY > keyHeight - yTranslate) ) {
+      && (mouseY < keyHeight + yTranslate) && (mouseY > yTranslate) ) {
       if (mouseIsPressed) {
         fill(0, 0, 0);
       } else {
@@ -105,9 +122,12 @@ function drawKeyboard() {
 
 // When we click
 function mousePressed() {
-  // Map mouse to the key index
-  var key = floor(map(mouseX, 0, width, 0, notes.length));
-  playNote(notes[key]);
+  
+  if(mouseOverKeys()) {
+    // Map mouse to the key index
+    var key = floor(map(mouseX, xTranslate, xTranslate + (notes.length * keyWidth), 0, notes.length));
+    playNote(notes[key]);
+  }
 }
 
 // Fade it out when we release

--- a/sketch.js
+++ b/sketch.js
@@ -11,16 +11,16 @@ var sustainSlider, sustain;
 var releaseSlider, release;
 
 var keyWidth, keyHeight;
-var xTranslate, yTranslate;
+var xTranslateKeys, yTranslateKeys;
 
 function setup() {
   createCanvas(1440, 800);
 
-  //Initializing some GUI element properties
+  // Initializing some GUI element properties
   keyWidth = width / (4 * notes.length);
   keyHeight = height / 4;
-  xTranslate = 800;
-  yTranslate = height / 2;
+  xTranslateKeys = 800;
+  yTranslateKeys = height / 2;
 
   setupSliders();
   
@@ -86,10 +86,10 @@ function draw() {
   drawKeyboard();
 }
 
-//Determines if the mouse is over any key on the keyboard  
+// Determines if the mouse is over any key on the keyboard  
 function mouseOverKeys() {
-  if ( (mouseX > xTranslate) && (mouseX < (notes.length * keyWidth) + xTranslate) 
-    && (mouseY < keyHeight + yTranslate) && (mouseY > yTranslate) ) {
+  if ( (mouseX > xTranslateKeys) && (mouseX < (notes.length * keyWidth) + xTranslateKeys) 
+    && (mouseY < keyHeight + yTranslateKeys) && (mouseY > yTranslateKeys) ) {
   
     return true;
   } else {
@@ -104,8 +104,8 @@ function drawKeyboard() {
     var x = i * keyWidth;
     
     // If the mouse is over the key
-    if ( (mouseX > x + xTranslate) && (mouseX < x + keyWidth + xTranslate) 
-      && (mouseY < keyHeight + yTranslate) && (mouseY > yTranslate) ) {
+    if ( (mouseX > x + xTranslateKeys) && (mouseX < x + keyWidth + xTranslateKeys) 
+      && (mouseY < keyHeight + yTranslateKeys) && (mouseY > yTranslateKeys) ) {
       if (mouseIsPressed) {
         fill(0, 0, 0);
       } else {
@@ -116,7 +116,7 @@ function drawKeyboard() {
     }
     
     // Draw the key
-    rect(x + xTranslate, yTranslate, keyWidth - 1, keyHeight - 1);
+    rect(x + xTranslateKeys, yTranslateKeys, keyWidth - 1, keyHeight - 1);
   }
 }
 
@@ -124,8 +124,7 @@ function drawKeyboard() {
 function mousePressed() {
   
   if(mouseOverKeys()) {
-    // Map mouse to the key index
-    var key = floor(map(mouseX, xTranslate, xTranslate + (notes.length * keyWidth), 0, notes.length));
+    var key = floor(map(mouseX, xTranslateKeys, xTranslateKeys + (notes.length * keyWidth), 0, notes.length));
     playNote(notes[key]);
   }
 }


### PR DESCRIPTION
#1

When highlighting a key you were checking if the mouse's y position was greater than a negative number. This has been fixed to check if it's greater than the "top" of the keyboard.

Keyboard scaling seemed to be a window wide issue, this has been decreased to the correct scaling. I also added an additional check to only calculate the ratio/play a note if the mouse if positioned above a key.
