### PR TITLE
Slider label bug fix

### DIFF
--- a/setupSliderLabel.js
+++ b/setupSliderLabel.js
@@ -2,13 +2,18 @@ function setupSliderLabel(sliderX, sliderY, verticalFlag, labelText) {
   var labelFontSize = floor(height / 75);
   textSize(labelFontSize);
   var labelWidth = textWidth(labelText);
+  var SLIDER_HEIGHT_MODIFIER = height * 123 / 1000;
   var labelX = sliderX;
   var labelY = sliderY;
   var label;
 
   if (verticalFlag) {
     labelX = labelX + (sliderHeight / 2);
-    labelY = labelY * 1.5;
+    labelY = labelY + floor(SLIDER_HEIGHT_MODIFIER / 2);
+  } else {
+
+    labelX = labelX + floor(height * 123 / 2000);
+    labelY = labelY + 10;
   }
 
   // Wrap text if the ratio of text width to canvas width is too big ( >= .08)

--- a/sketch.js
+++ b/sketch.js
@@ -48,7 +48,7 @@ function setupSliders() {
   sustainSlider = setupSlider(xTranslateSliders + (2 * sliderSpacer), 2.5 * sliderHeight, 256, 0, true);
   setupSliderLabel(xTranslateSliders + (2 * sliderSpacer), 2.5 * sliderHeight, true, 'S');
   releaseSlider = setupSlider(xTranslateSliders + (3 * sliderSpacer), 2.5 * sliderHeight, 256, 25, true);
-  setupSliderLabel(xTranslateSliders + (3 * sliderSpacer), 2.5 * sliderHeight, true, 'R');
+  setupSliderLabel(xTranslateSliders + (3 * sliderSpacer), 2 * sliderHeight, true, 'R');
   // Oscillator sliders
   sawSlider = setupSlider(xTranslateSliders + (15 * sliderSpacer), sliderHeight, 256, 100, true);
   setupSliderLabel(xTranslateSliders + (15 * sliderSpacer), sliderHeight, true, 'SAW');
@@ -58,10 +58,6 @@ function setupSliders() {
   setupSliderLabel(xTranslateSliders + (17 * sliderSpacer), sliderHeight, true, 'TRI');
   subSlider = setupSlider(xTranslateSliders + (18 * sliderSpacer), sliderHeight, 256, 0, true);
   setupSliderLabel(xTranslateSliders + (18 * sliderSpacer), sliderHeight, true, 'SUB');
-
-//  rect(200, 0, 20, 0);
-
-
 }
 
 function loadVisualElements() {

--- a/sketch.js
+++ b/sketch.js
@@ -33,7 +33,8 @@ var xTranslateKeys, yTranslateKeys;
 function setupSliders() {
   // Octave slider
   octaveSlider = setupSlider(xTranslateSliders + (19 * sliderSpacer), 3.5 * sliderHeight, 4, 2, false);
-  setupSliderLabel(xTranslateSliders + (20.5 * sliderSpacer), 3.5 * sliderHeight, false, 'Octave');
+  setupSliderLabel(xTranslateSliders + (19 * sliderSpacer), 3.5 * sliderHeight, false, 'Octave');
+  //setupSliderLabel(xTranslateSliders + (20.5 * sliderSpacer), 3.5 * sliderHeight, false, 'Octave');
   // Filter sliders
   filterFreqSlider = setupSlider(xTranslateSliders + (0 * sliderSpacer), sliderHeight, 1024, 1024, true);
   setupSliderLabel(xTranslateSliders + (0 * sliderSpacer), sliderHeight, true, 'Filter Frequency');
@@ -41,13 +42,13 @@ function setupSliders() {
   setupSliderLabel(xTranslateSliders + (2 * sliderSpacer), sliderHeight, true, 'Filter Resonance');
   // ADSR sliders
   attackSlider  = setupSlider(xTranslateSliders + (0 * sliderSpacer), 2.5 * sliderHeight, 256, 0, true);
-  setupSliderLabel(xTranslateSliders + (0 * sliderSpacer), 2 * sliderHeight, true, 'A');
+  setupSliderLabel(xTranslateSliders + (0 * sliderSpacer), 2.5 * sliderHeight, true, 'A');
   decaySlider   = setupSlider(xTranslateSliders + (1 * sliderSpacer), 2.5 * sliderHeight, 256, 25, true);
-  setupSliderLabel(xTranslateSliders + (1 * sliderSpacer), 2 * sliderHeight, true, 'D');
+  setupSliderLabel(xTranslateSliders + (1 * sliderSpacer), 2.5 * sliderHeight, true, 'D');
   sustainSlider = setupSlider(xTranslateSliders + (2 * sliderSpacer), 2.5 * sliderHeight, 256, 0, true);
-  setupSliderLabel(xTranslateSliders + (2 * sliderSpacer), 2 * sliderHeight, true, 'S');
+  setupSliderLabel(xTranslateSliders + (2 * sliderSpacer), 2.5 * sliderHeight, true, 'S');
   releaseSlider = setupSlider(xTranslateSliders + (3 * sliderSpacer), 2.5 * sliderHeight, 256, 25, true);
-  setupSliderLabel(xTranslateSliders + (3 * sliderSpacer), 2 * sliderHeight, true, 'R');
+  setupSliderLabel(xTranslateSliders + (3 * sliderSpacer), 2.5 * sliderHeight, true, 'R');
   // Oscillator sliders
   sawSlider = setupSlider(xTranslateSliders + (15 * sliderSpacer), sliderHeight, 256, 100, true);
   setupSliderLabel(xTranslateSliders + (15 * sliderSpacer), sliderHeight, true, 'SAW');
@@ -57,6 +58,10 @@ function setupSliders() {
   setupSliderLabel(xTranslateSliders + (17 * sliderSpacer), sliderHeight, true, 'TRI');
   subSlider = setupSlider(xTranslateSliders + (18 * sliderSpacer), sliderHeight, 256, 0, true);
   setupSliderLabel(xTranslateSliders + (18 * sliderSpacer), sliderHeight, true, 'SUB');
+
+//  rect(200, 0, 20, 0);
+
+
 }
 
 function loadVisualElements() {


### PR DESCRIPTION
#40

Modified horizontal slider labels so that they now appear centered underneath of the slider. Maybe add an optional arg for on top of or left/right of? 

Vertical slider labels have had their multiplier changed from 1.5 \* height, which caused obvious spacing issues, to approx height / 2 \* .123 (half of the height of the slider itself)
